### PR TITLE
issue #102 map sessions to speakers

### DIFF
--- a/data/posts/speakers.json
+++ b/data/posts/speakers.json
@@ -21,7 +21,12 @@
       }
     ],
       "order" : 0,
-      "title" : "Programmer / Author / Teacher"
+      "title" : "Programmer / Author / Teacher",
+      "sessions":[
+        {
+          "id": 101
+        }
+      ]
     },
     {
       "id":"guillaume_marty",
@@ -41,9 +46,9 @@
       "title" : "Web lover / JavaScript activist / HTML5 enthusiast"
     }
   ],
-  "sessions":
-  [
+  "sessions" : [
     {
+      "id":101,
       "complexity" : "Intermediate",
       "description" : "Research indicates that programmers are not entirely happy, and that much of this unhappiness arises from interactions with other people.  Research also tells us that teams are capable of producing solutions that are more creative and of higher quality than those of single individuals.  However, teams, by definition, consist of people--possibly the very ones who are causing our unhappiness.<br><br>This talk explores the science behind human persuasion, examines the roots of motivation, and reveals the single quality that all high-performing teams share.  You’ll leave armed to persuade, primed to understand, and motivated to create teams that inspire everyone to do their best work.",
       "speakers" : [ "sandi_metz" ],
@@ -51,4 +56,5 @@
       "title" : "You Are Insufficiently Persuasive"
     }
   ]
+
 }

--- a/data/posts/speakers.json
+++ b/data/posts/speakers.json
@@ -6,6 +6,7 @@
       "featured": true,
       "bio" : "Sandi Metz, author of Practical Object-Oriented Design in Ruby and 99 Bottles of OOP, believes in simple code and straightforward explanations. She prefers working software, practical solutions and lengthy bicycle trips (not necessarily in that order) and writes, consults, and teaches about object-oriented design.",
       "name" : "Sandi Metz",
+      "country": "USA",
       "photo" : "/images/speakers/sandimetz_2016.jpg",
       "photoUrl" : "/images/speakers/sandimetz_2016.jpg",
       "socials" : [
@@ -33,6 +34,8 @@
       "featured": true,
       "bio" : "Guillaume Marty has been working on the web for 77% of its lifespan. In the last few years he shifted his focus from code to humans. He's passionate about contributing to a healthy, inclusive industry, and the intersection between communities and technology. He was formerly working at Mozilla, and currently at Twitter.",
       "name" : "Guillaume Marty",
+      "company": "Twitter",
+      "country": "United Kingdom",
       "photo" : "/images/speakers/guillaume-marty.jpg",
       "photoUrl" : "/images/speakers/guillaume-marty.jpg",
       "socials" : [

--- a/data/settings.json
+++ b/data/settings.json
@@ -15,7 +15,7 @@
     "locale": "en-US"
   },
   "hashtag": "LibertyJS19",
-  "disabledSchedule": false,
+  "disabledSchedule": true,
   "showSessionShortAbstract": true,
   "navigation": [
     {

--- a/functions/src/schedule-generator/speakers-sessions-map.js
+++ b/functions/src/schedule-generator/speakers-sessions-map.js
@@ -25,7 +25,7 @@ function sessionsSpeakersMap(sessionsRaw, speakersRaw) {
                     [...generatedSpeaker.sessions, sessionBySpeaker] :
                     [sessionBySpeaker];
 
-                    speakers[speakerId] = { 
+                    speakers[speakerId] = {
                         ...generatedSpeaker,
                         tags: [...speakerTags],
                         sessions: speakerSessions,

--- a/scripts/redux/actions.js
+++ b/scripts/redux/actions.js
@@ -381,8 +381,21 @@ const sessionsActions = {
             const tagFilters = new Set();
             const complexityFilters = new Set();
             const doc = res.sessions;
+            let speakers = res.speakers;
             doc.forEach((session) => {
               // const session = Object.assign({}, doc.data());
+
+              // map speaker to session
+            // will need to do this for schedule
+            if (session.speakers) {
+              session.speakers.forEach((sessionSpeaker, index) =>{
+                speakers.forEach((speaker) =>{
+                  if (sessionSpeaker === speaker.id) {
+                    session.speakers[index] = speaker;
+                  }
+                });
+              });
+            }
               list.push(session);
               session.tags && session.tags.map((tag) => tagFilters.add(tag.trim()));
               session.complexity && complexityFilters.add(session.complexity.trim());

--- a/src/elements/dialogs/session-details.html
+++ b/src/elements/dialogs/session-details.html
@@ -124,7 +124,7 @@
 
                 <div class="section-details" flex>
                   <div class="section-primary-text">[[speaker.name]]</div>
-                  <div class="section-secondary-text">[[speaker.company]] / [[speaker.country]]</div>
+                  <div class="section-secondary-text">[[speaker.company]] <span hidden$="[[!speaker.company]] || [[!speaker.country]]"> / </span> [[speaker.country]]</div>
                 </div>
               </div>
             </div>

--- a/src/elements/dialogs/speaker-details.html
+++ b/src/elements/dialogs/speaker-details.html
@@ -97,7 +97,7 @@
 
       <div class="dialog-container content">
         <h3 class="meta-info">[[speaker.country]]</h3>
-        <h3 class="meta-info">[[speaker.title]], [[speaker.company]]</h3>
+        <h3 class="meta-info">[[speaker.title]]<span hidden$="[[!speaker.company]]">, [[speaker.company]]</span></h3>
         <h3 class="meta-info" hidden$="[[isEmpty(speaker.badges)]]">
           <template is="dom-repeat" items="[[speaker.badges]]" as="badge">
             <a
@@ -190,7 +190,7 @@
 
       _close() {
         dialogsActions.closeDialog(DIALOGS.SPEAKER);
-        // history.back();
+        history.back();
       }
 
       _openSession(e) {

--- a/src/elements/dialogs/speaker-details.html
+++ b/src/elements/dialogs/speaker-details.html
@@ -130,6 +130,7 @@
         <div class="additional-sections" hidden$="[[!speaker.sessions.length]]">
           <h3>{$ speakerDetails.sessions $}</h3>
 
+
           <template is="dom-repeat" items="[[speaker.sessions]]" as="session">
             <div on-tap="_openSession" session-id$="[[session.id]]" class="section">
               <div layout horizontal center>

--- a/src/mixins/sessions-hoc.html
+++ b/src/mixins/sessions-hoc.html
@@ -31,7 +31,6 @@
 
     connectedCallback() {
       super.connectedCallback();
-
       if (!this.sessionsFetching && (!this.sessions || !this.sessions.length)) {
         this.dispatch(sessionsActions.fetchList());
       }


### PR DESCRIPTION
#102 When we pull down session and speaker data, i make sure to map both to eachother. Original hoverboard code did this when pushing to the database and created something called generatedSpeakers or generatedSessions.

We will need to do the same thing when we start creating the schedule. For now i turned on the global variable `"disabledSchedule": true,` in settings.json until we're ready to create one