### PR TITLE
issue143/remove-tag-color

### DIFF
--- a/src/elements/shared-styles.html
+++ b/src/elements/shared-styles.html
@@ -59,7 +59,6 @@
         --android: #78c257;
         --web: #2196f3;
         --cloud: #3f51b5;
-        --community: #e91e63;
         --design: #E91E63;
       }
 


### PR DESCRIPTION
Removed color from community tag.

Link to issue: https://github.com/LibertyJS/libertyjs-web2.0/issues/143