### PR TITLE
Remove min-width media query to fix gap above header-bottom-toolbar

### DIFF
--- a/src/elements/sticky-element.html
+++ b/src/elements/sticky-element.html
@@ -36,12 +36,6 @@
         opacity: 1;
       }
 
-      @media (min-width: 812px) {
-        .sticked {
-          margin-top: 64px;
-        }
-      }
-
     </style>
 
     <div id="trigger"></div>


### PR DESCRIPTION
This media query was causing a gap between the main header and and the `header-bottom-toolbar` element.

Old:
<img width="755" alt="Screenshot 2023-10-13 at 9 47 39 AM" src="https://github.com/LibertyJS/libertyjs-web2.0/assets/755353/c63f362f-e447-42b3-86a8-e85ffcaac9e0">

New:
<img width="711" alt="Screenshot 2023-10-13 at 9 48 16 AM" src="https://github.com/LibertyJS/libertyjs-web2.0/assets/755353/4f2fd659-36d5-4223-a131-716aef5d73c8">

